### PR TITLE
secret key rotation: fix key list ordering

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+0.11.1 (Unreleased)
+-------------------
+
+* Flask backport: Fix signing key selection order when key rotation is enabled
+  via ``SECRET_KEY_FALLBACKS``.
+  <https://github.com/pallets/flask/security/advisories/GHSA-4grg-w6v8-c28g>
+
 0.11.0 2024-12-26
 -----------------
 

--- a/src/quart_auth/extension.py
+++ b/src/quart_auth/extension.py
@@ -205,10 +205,12 @@ class QuartAuth:
         if app is None:
             app = current_app
 
-        keys = [app.secret_key]
+        keys = []
 
         if fallbacks := app.config.get("SECRET_KEY_FALLBACKS"):
             keys.extend(fallbacks)
+
+        keys.append(app.secret_key)  # itsdangerous expects current key at top
 
         serializer = self.serializer_class(keys, self.salt)  # type: ignore[arg-type]
         try:


### PR DESCRIPTION
Backports the fix for GHSA-4grg-w6v8-c28g from `flask` to `quart-auth`.